### PR TITLE
Fixed the overlayMap function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/createMap.cpython-312.pyc
+__pycache__/detectMarkers.cpython-312.pyc
+__pycache__/getCameraFeed.cpython-312.pyc
+__pycache__/identifyHighground.cpython-312.pyc
+__pycache__/identifySpiceSand.cpython-312.pyc
+__pycache__/objectTracking.cpython-312.pyc
+__pycache__/overlayMap.cpython-312.pyc
+__pycache__/mainLoop.cpython-312.pyc

--- a/overlayMap.py
+++ b/overlayMap.py
@@ -4,12 +4,23 @@ def overlayMap(frame, map_data):
     babySpice = map_data.get('babySpice', [])
     sandworm = map_data.get('sandworm', [])
 
+    # The two objects are the corners of the ArUco markers on the image plane
+    # We need to find the point in the middle of the first and the third corner to overlay the object
+    # Check if babySpice and sandworm are not empty and are lists
+    if babySpice and isinstance(babySpice, list):
+        for i in babySpice:
+            babySpicecircle = [(int((i[0][0][0] + i[0][2][0]) / 2), int((i[0][0][1] + i[0][2][1]) / 2))]
+                               
+    if sandworm and isinstance(sandworm, list):
+        for i in sandworm:
+            sandwormcircle = [(int((i[0][0][0] + i[0][2][0]) / 2), int((i[0][0][1] + i[0][2][1]) / 2))]
+
     # Overlay babySpice and sandworm on the frame if they are not empty
-    if babySpice and isinstance(babySpice, list) and all(isinstance(i, list) and len(i) == 2 for i in babySpice):
-        for (x, y) in babySpice:
+    if babySpicecircle and isinstance(babySpicecircle, list) and all(len(i) == 2 for i in babySpicecircle):
+        for (x, y) in babySpicecircle:
             cv2.circle(frame, (x, y), 100, (255, 0, 0), -1)  
-    if sandworm and isinstance(sandworm, list) and all(isinstance(i, list) and len(i) == 2 for i in sandworm):
-        for (x, y) in sandworm:
+    if sandwormcircle and isinstance(sandwormcircle, list) and all(len(i) == 2 for i in sandwormcircle):
+        for (x, y) in sandwormcircle:
             cv2.circle(frame, (x, y), 100, (0, 0, 255), -1)  
 
     return frame

--- a/testfunctions.py
+++ b/testfunctions.py
@@ -1,0 +1,17 @@
+import cv2
+import time
+from mainLoop import process_frame
+
+# Read the JPG image
+image_path = 'sample.jpg'
+frame = cv2.imread(image_path)
+
+ret = True  # Typically True if the frame is successfully read
+
+# Call the function with the ret value and the frame
+overlay_frame, highground, spice, sand, babySpice, sandworm = process_frame(ret, frame)
+
+# show the overlay_frame to visualize the result
+cv2.imshow("Live Feed with Overlay", overlay_frame)
+cv2.waitKey(0)
+cv2.destroyAllWindows


### PR DESCRIPTION
The original version was using the corners of the Aruco marker. This was changed to find the point between the two opposite corners and use that as the center of the circle.

Added the .gitignore file to ignore the __pycache__ folder and the .pyc files.